### PR TITLE
Add new cli for SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS counter in counterpoll utility

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -5,6 +5,7 @@ from tabulate import tabulate
 
 BUFFER_POOL_WATERMARK = "BUFFER_POOL_WATERMARK"
 PORT_BUFFER_DROP = "PORT_BUFFER_DROP"
+PG_DROP = "PG_DROP"
 DISABLE = "disable"
 ENABLE = "enable"
 DEFLT_60_SEC= "default (60000)"
@@ -123,6 +124,43 @@ def disable():
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
 
+# Ingress PG drop packet stat
+@cli.group()
+def pg_drop():
+    """  Ingress PG drop counter commands """
+    pass
+
+@pg_drop.command()
+@click.argument('poll_interval', type=click.IntRange(1000, 30000))
+def interval(poll_interval):
+    """
+    Set pg_drop packets counter query interval
+    interval is between 1s and 30s.
+    """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PG_DROP, port_info)
+
+@pg_drop.command()
+def enable():
+    """ Enable pg_drop counter query """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = ENABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PG_DROP, port_info)
+
+@pg_drop.command()
+def disable():
+    """ Disable pg_drop counter query """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = DISABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PG_DROP, port_info)
+
 # RIF counter commands
 @cli.group()
 def rif():
@@ -212,6 +250,7 @@ def show():
     rif_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'RIF')
     queue_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE_WATERMARK')
     pg_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_WATERMARK')
+    pg_drop_info = configdb.get_entry('FLEX_COUNTER_TABLE', PG_DROP)
     buffer_pool_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', BUFFER_POOL_WATERMARK)
     
     header = ("Type", "Interval (in ms)", "Status")
@@ -228,6 +267,8 @@ def show():
         data.append(["QUEUE_WATERMARK_STAT", queue_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), queue_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if pg_wm_info:
         data.append(["PG_WATERMARK_STAT", pg_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), pg_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if pg_drop_info:
+        data.append(['PG_DROP_STAT', port_drop_info.get("POLL_INTERVAL", DEFLT_10_SEC), pg_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if buffer_pool_wm_info:
         data.append(["BUFFER_POOL_WATERMARK_STAT", buffer_pool_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), buffer_pool_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
 

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -25,6 +25,7 @@ PORT_STAT                           1000  enable
 PORT_BUFFER_DROP                   60000  enable
 QUEUE_WATERMARK_STAT               10000  enable
 PG_WATERMARK_STAT                  10000  enable
+PG_DROP_STAT                       10000  enable
 """
 
 class TestCounterpoll(object):
@@ -54,6 +55,20 @@ class TestCounterpoll(object):
         assert result.exit_code == 2
         assert expected in result.output
 
+    def test_pg_drop_interval(self):
+        runner = CliRunner()
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands["interval"], ["10000"])
+        print(result.output)
+        assert result.exit_code == 0
+
+    def test_pg_drop_interval_too_long(self):
+        runner = CliRunner()
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands["interval"], ["50000"])
+        print(result.output)
+        expected = "Invalid value for \"POLL_INTERVAL\": 50000 is not in the valid range of 1000 to 30000."
+        assert result.exit_code == 2
+        assert expected in result.output
+
     @pytest.fixture(scope='class')
     def _get_config_db_file(self):
         sample_config_db_file = os.path.join(test_path, "counterpoll_input", "config_db.json")
@@ -75,6 +90,13 @@ class TestCounterpoll(object):
         if "FLEX_COUNTER_TABLE" in config_db:
             for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
                 assert counter_config["FLEX_COUNTER_STATUS"] == status
+
+    @pytest.mark.parametrize("status", ["disable", "enable"])
+    def test_update_pg_drop_status(self, status):
+        runner = CliRunner()
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands[status])
+        print(result.output)
+        assert result.exit_code == 0
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1256,6 +1256,10 @@
         "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
+    "FLEX_COUNTER_TABLE|PG_DROP": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
     "PFC_WD|Ethernet0": {
         "action": "drop",
         "detection_time": "600",


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added new option for "counterpoll" util

**- How I did it**
Add appropriate code to counterpoll/main.py 

**- How to verify it**
```
admin@arc-switch1041:~$ counterpoll pg-drop enable  --> anable new counter
admin@arc-switch1041:~$ counterpoll show  --> check new INGRESS_PG_STAT_DROP  counter status
```

check counters
```
admin@arc-switch1041:~$ redis-cli -n 2
127.0.0.1:6379[2]> HGETALL COUNTERS:oid:0x1a000000000062
1) "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES"
2) "0"
3) "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES"
4) "0"
5) "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
6) "0"
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

