### PR TITLE
Run pfcwd only on ports where pfc is enabled

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -11,6 +11,11 @@ from sonic_py_common.multi_asic import get_external_ports
 from tabulate import tabulate
 from utilities_common import multi_asic as multi_asic_util
 from utilities_common import constants
+from sonic_py_common import logger
+
+SYSLOG_IDENTIFIER = "config"
+
+log = logger.Logger(SYSLOG_IDENTIFIER)
 
 # mock the redis for unit test purposes #
 try:
@@ -242,9 +247,20 @@ class PfcwdCli(object):
             exit()
         self.start_cmd(action, restoration_time, ports, detection_time)
 
-    def get_port_pfc_status(self, port):
-        status = self.config_db.get_entry(PORT_QOS_MAP, port).get('pfc_enable')
-        return status
+
+    def verify_pfc_enable_status_per_port(self, port):
+        pfc_status = self.config_db.get_entry(PORT_QOS_MAP, port).get('pfc_enable')
+
+        if pfc_status == None:
+            log.log_warning("SKIPPED: PFC is not enabled on port: {}".format(port), also_print_to_console=True)
+            return
+
+        self.config_db.mod_entry(
+            CONFIG_DB_PFC_WD_TABLE_NAME, port, None
+        )
+        self.config_db.mod_entry(
+            CONFIG_DB_PFC_WD_TABLE_NAME, port, pfcwd_info
+        )
 
     @multi_asic_util.run_on_multi_asic
     def start_cmd(self, action, restoration_time, ports, detection_time):
@@ -276,29 +292,11 @@ class PfcwdCli(object):
         for port in ports:
             if port == "all":
                 for p in all_ports:
-                    pfc_status = self.get_port_pfc_status(p)
-                    if pfc_status == None:
-                        print("SKIPPED: PFC is not enabled on port: {}".format(p))
-                        continue
-
-                    self.config_db.mod_entry(
-                        CONFIG_DB_PFC_WD_TABLE_NAME, p, None
-                    )
-                    self.config_db.mod_entry(
-                        CONFIG_DB_PFC_WD_TABLE_NAME, p, pfcwd_info
-                    )
+                    self.verify_pfc_enable_status_per_port(p)
             else:
-                pfc_status = self.get_port_pfc_status(port)
-                if port not in all_ports or pfc_status == None:
-                    print("SKIPPED: PFC is not enabled on port: {}".format(port))
+                if port not in all_ports:
                     continue
-
-                self.config_db.mod_entry(
-                    CONFIG_DB_PFC_WD_TABLE_NAME, port, None
-                )
-                self.config_db.mod_entry(
-                    CONFIG_DB_PFC_WD_TABLE_NAME, port, pfcwd_info
-                )
+                self.verify_pfc_enable_status_per_port(port)
 
     @multi_asic_util.run_on_multi_asic
     def interval(self, poll_interval):

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -108,6 +108,27 @@
         "BIG_RED_SWITCH": "enable",
         "POLL_INTERVAL": "199"
     },
+    "PORT_QOS_MAP|Ethernet0": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet4": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet8": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP0": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP4": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP256": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP260": {
+        "pfc_enable": "3,4"
+    },
     "CRM|Config": {
         "acl_table_threshold_type": "percentage",
         "nexthop_group_threshold_type": "percentage",

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -77,6 +77,27 @@
         "BIG_RED_SWITCH": "enable",
         "POLL_INTERVAL": "199"
     },
+    "PORT_QOS_MAP|Ethernet0": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet4": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet8": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP0": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP4": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP256": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet-BP260": {
+        "pfc_enable": "3,4"
+    },
     "CRM|Config": {
         "acl_table_threshold_type": "percentage",
         "nexthop_group_threshold_type": "percentage",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1432,6 +1432,12 @@
     "PORT_QOS_MAP|Ethernet0": {
         "pfc_enable": "3,4"
     },
+    "PORT_QOS_MAP|Ethernet4": {
+        "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|Ethernet8": {
+        "pfc_enable": "3,4"
+    },
     "DEFAULT_LOSSLESS_BUFFER_PARAMETER|AZURE": {
         "default_dynamic_th": "0",
         "over_subscribe_ratio": "2"

--- a/tests/pfcwd_input/pfcwd_test_vectors.py
+++ b/tests/pfcwd_input/pfcwd_test_vectors.py
@@ -94,6 +94,8 @@ pfcwd_show_stats_invalid_queue_output="""\
 -------  --------  -------------------------  ------------  ------------  -----------------  -----------------
 """
 
+pfc_is_not_enabled = "SKIPPED: PFC is not enabled on port: Ethernet0\n"
+
 testData = {
              'pfcwd_show_config' :  [ {'cmd' : ['show', 'config'],
                                        'args': [],

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -192,6 +192,37 @@ class TestPfcwd(object):
         assert result.exit_code == 0
         assert result.output == pfcwd_show_start_action_drop_output
 
+    @patch('pfcwd.main.os')
+    def test_pfcwd_pfc_not_enabled(self, mock_os):
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        # get initial config
+        result = runner.invoke(
+            pfcwd.cli.commands["show"].commands["config"],
+            obj=db
+        )
+        print(result.output)
+        assert result.output == pfcwd_show_config_output
+
+        mock_os.geteuid.return_value = 0
+        # remove 'pfc_enabled' entry from Ethernet0 node
+        db.cfgdb.mod_entry("PORT_QOS_MAP", "Ethernet0", None)
+
+        result = runner.invoke(
+        pfcwd.cli.commands["start"],
+            [
+                "--action", "drop", "--restoration-time", "601",
+                "Ethernet0", "602"
+            ],
+            obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 0
+        assert pfc_is_not_enabled == result.output
+
+
     def test_pfcwd_start_ports_invalid(self):
         # pfcwd start --action drop --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I fixed flood of messages:
```
Nov 13 17:27:22.878468 arc-switch1038 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet100
Nov 13 17:27:23.878620 arc-switch1038 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet100
```

#### How I did it
I added protection  - now we check if PFC  is enabled on port before enabling PWD

#### How to verify it
**EthernetX**-  port that has not configured PFC (usually admin state 'down' by default)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

```
SKIPPED: PFC is not enabled on port: Ethernet0
SKIPPED: PFC is not enabled on port: Ethernet66
```