### PR TITLE
[show priority-group drop counters] Add user info output when user want to check PG counters and polling are disabled

### DIFF
--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -9,6 +9,7 @@ import _pickle as pickle
 import argparse
 import os
 import sys
+from swsscommon.swsscommon import ConfigDBConnector
 from collections import OrderedDict
 
 from natsort import natsorted
@@ -46,6 +47,9 @@ class PgDropStat(object):
     def __init__(self):
         self.counters_db = SonicV2Connector(host='127.0.0.1')
         self.counters_db.connect(self.counters_db.COUNTERS_DB)
+
+        self.configdb = ConfigDBConnector()
+        self.configdb.connect()
 
         dropstat_dir = get_dropstat_dir()
         self.port_drop_stats_file = os.path.join(dropstat_dir, 'pg_drop_stats')
@@ -212,6 +216,13 @@ class PgDropStat(object):
             sys.exit(e.errno)
         print("Cleared PG drop counter")
 
+    def check_if_stats_enabled(self):
+        pg_drop_info = self.configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_DROP')
+        if pg_drop_info:
+            status = pg_drop_info.get("FLEX_COUNTER_STATUS", 'disable')
+            if status == "disable":
+                print("Warning: PG counters are disabled. Current stats may be outdated. Use 'counterpoll pg-drop enable' to enable polling")
+
 def main():
     parser = argparse.ArgumentParser(description='Display PG drop counter',
                                      formatter_class=argparse.RawTextHelpFormatter,
@@ -240,6 +251,7 @@ pg-drop -c clear
     if command == 'clear':
         pgdropstat.clear_drop_counts()
     elif command == 'show':
+        pgdropstat.check_if_stats_enabled()
         pgdropstat.print_all_stat(COUNTER_TABLE_PREFIX, "pg_drop" )
     else:
         print("Command not recognized")

--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -9,7 +9,6 @@ import _pickle as pickle
 import argparse
 import os
 import sys
-from swsscommon.swsscommon import ConfigDBConnector
 from collections import OrderedDict
 
 from natsort import natsorted
@@ -27,7 +26,7 @@ try:
 except KeyError:
     pass
 
-from swsscommon.swsscommon import SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 
 STATUS_NA = 'N/A'
 

--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -220,7 +220,8 @@ class PgDropStat(object):
         if pg_drop_info:
             status = pg_drop_info.get("FLEX_COUNTER_STATUS", 'disable')
             if status == "disable":
-                print("Warning: PG counters are disabled. Current stats may be outdated. Use 'counterpoll pg-drop enable' to enable polling")
+                print("Warning: PG counters are disabled. Use 'counterpoll pg-drop enable' to enable polling")
+                sys.exit(0)
 
 def main():
     parser = argparse.ArgumentParser(description='Display PG drop counter',

--- a/tests/pgdrop_input/config_db.json
+++ b/tests/pgdrop_input/config_db.json
@@ -1,0 +1,26 @@
+{
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "FLEX_COUNTER_TABLE|PORT": {
+        "POLL_INTERVAL": "1000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "FLEX_COUNTER_TABLE|PORT_BUFFER_DROP": {
+        "POLL_INTERVAL": "60000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE_WATERMARK": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "FLEX_COUNTER_TABLE|PG_DROP": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "disable"
+    }
+}

--- a/tests/pgdropstat_test.py
+++ b/tests/pgdropstat_test.py
@@ -1,10 +1,12 @@
 import os
 import sys
+import pytest
 
 import show.main as show
 import clear.main as clear
 
 from click.testing import CliRunner
+from shutil import copyfile
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -37,6 +39,29 @@ class TestPgDropstat(object):
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
         print("SETUP")
+
+    @pytest.fixture(scope='function')
+    def replace_config_db_file(self):
+        sample_config_db_file = os.path.join(test_path, "pgdrop_input", "config_db.json")
+        mock_config_db_file = os.path.join(test_path, "mock_tables", "config_db.json")
+
+        #Backup origin config_db and replace it with config_db file with disabled PG_DROP counters 
+        copyfile(mock_config_db_file, "/tmp/config_db.json")
+        copyfile(sample_config_db_file, mock_config_db_file)
+
+        yield
+
+        copyfile("/tmp/config_db.json", mock_config_db_file)
+
+    def test_show_pg_drop_disabled(self, replace_config_db_file):
+        runner = CliRunner()
+
+        result = runner.invoke(show.cli.commands["priority-group"].commands["drop"].commands["counters"])
+        assert result.exit_code == 0
+        print(result.exit_code)
+
+        assert result.output == "Warning: PG counters are disabled. Use 'counterpoll pg-drop enable' to enable polling\n"
+        print(result.output)
 
     def test_show_pg_drop_show(self):
         self.executor(clear_before_show = False)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added additional output info for user when trying to show priority group counters and 

#### How I did it
modify pg-drop script, add additional print during executing  "show priority-group drop counters" if PG polling disabled

#### How to verify it
```
counterpoll pg-drop disable
show priority-group drop counters
```
Expect:
`Warning: PG counters are disabled. Current stats may be outdated. Use 'counterpoll pg-drop enable' to enable'`


#### Previous command output (if the output of a command-line utility has changed)
```
admin@r-tigon-04:/usr/local/bin$ show priority-group drop counters
Ingress PG dropped packets:
       Port    PG0    PG1    PG2    PG3    PG4    PG5    PG6    PG7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet2      0      0      0      0      0      0      0      0
  Ethernet8      0      0      0      0      0      0      0      0
 Ethernet10      0      0      0      0      0      0      0      0
 Ethernet16      0      0      0      0      0      0      0      0
```


#### New command output (if the output of a command-line utility has changed)
```
admin@r-tigon-04:/usr/local/bin$ show priority-group drop counters
Warning: PG counters are disabled. Current stats may be outdated. Use 'counterpoll pg-drop enable' to enable
Ingress PG dropped packets:
       Port    PG0    PG1    PG2    PG3    PG4    PG5    PG6    PG7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet2      0      0      0      0      0      0      0      0
  Ethernet8      0      0      0      0      0      0      0      0
 Ethernet10      0      0      0      0      0      0      0      0
 Ethernet16      0      0      0      0      0      0      0      0
```


