### PR TITLE
[show techsupport] remove '-it' while executing binaries via 'docker exec' in generate_dump script

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -761,8 +761,8 @@ collect_mellanox() {
     local sai_dump_folder="/tmp/saisdkdump"
     local sai_dump_filename="${sai_dump_folder}/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
 
-    ${CMD_PREFIX}docker exec -it syncd mkdir -p $sai_dump_folder
-    ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
+    ${CMD_PREFIX}docker exec syncd mkdir -p $sai_dump_folder
+    ${CMD_PREFIX}docker exec syncd saisdkdump -f $sai_dump_filename
 
     copy_from_docker syncd $sai_dump_folder $sai_dump_folder
     echo "$sai_dump_folder"
@@ -771,7 +771,7 @@ collect_mellanox() {
     done
 
     ${CMD_PREFIX}rm -rf $sai_dump_folder
-    ${CMD_PREFIX}docker exec -it syncd rm -rf $sai_dump_folder
+    ${CMD_PREFIX}docker exec syncd rm -rf $sai_dump_folder
     
     # Save SDK error dumps
     local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
While executing "show_techsupport" test was found that when "docker exec" command in generate_dump script executed with '-it' option it may be not executed at all. 
So suggest to remove options that provoked problems while executing. 

#### How I did it
removed '-it'  (interactive tty) option while executing "docker exec -it syncd saisdkdump"

#### How to verify it
run show techsupport test with debug messages
You will be able to find in logs something like this:
```
 "init_buffer_resource_limits[", 
 "num_ingress_pools:8", 
 "num_egress_pools:8",
 "num_shared_headroom_pools:1", 
 "num_total_pools:42", 
 "num_port_queue_buff:16", 
 "num_port_pg_buff:8", 
 "num_headroom_port_buff:9", 
 "unit_size:144", 
 "max_buffers_per_port:94", 
 "init_buffer_resource_limits]", 
 "mlnx_init_buffer_pool_ids[", 
 "default_ingress_pool_id:0", 
 "management_ingress_pool_id:2",
 "base_ingress_user_sx_pool_id:4", 
 "default_egress_pool_id:12", 
 "management_egress_pool_id:14", 
 "base_egress_user_sx_pool_id:16",
 "default_multicast_pool_id:10", 
 "user_pool_step:2", 
 "mlnx_init_buffer_pool_ids]", 
 "The SAI dump is generated to /tmp/sai_sdk_dump_07_08_2021_03_49_PM", 
 "mkdir: created directory '/var/dump/sonic_dump_r-leopard-01_20210708_154816/sai_sdk_dump'",
 "sonic_dump_r-leopard-01_20210708_154816/sai_sdk_dump/sai_sdk_dump_07_08_2021_03_49_PM.gz", 
 "removed '/var/dump/sonic_dump_r-leopard-01_20210708_154816/sai_sdk_dump/sai_sdk_dump_07_08_2021_03_49_PM.gz'", 
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

