### PR TITLE
[generate_dump] exclude mft and mlx folders from /etc 

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1294,8 +1294,8 @@ main() {
         --exclude="*/etc/ssh*" \
         --exclude="*get_creds*" \
         --exclude="*snmpd.conf*" \
-        --exclude="/etc/mlnx" \
-        --exclude="/etc/mft" \
+        --exclude="*/etc/mlnx" \
+        --exclude="*/etc/mft" \
         --exclude="*/etc/sonic/*.cer" \
         --exclude="*/etc/sonic/*.crt" \
         --exclude="*/etc/sonic/*.pem" \


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
exclude mft and mlnx folders from /etc during execution generate_dump*  

#### How I did it
Fix appropriate --exclude pattern in **tar** cmd execution   (add * character )

#### How to verify it
Test should pass successfully 
`py.test  test_techsupport.py::test_secret_removed_from_show_techsupport --inventory="../ansible/inventory,../ansible/veos" --host-pattern {testbad} --module-path ../ansible/library/ --testbed {testbad}-{topo} --testbed_file ../ansible/testbed.csv --allow_recover  --assert plain --log-cli-level info --show-capture=no -ra --showlocals -v --skip_sanity
`
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

