### PR TITLE
[crm] add checking for CRM interval range

### DIFF
--- a/crm/main.py
+++ b/crm/main.py
@@ -237,9 +237,9 @@ def polling(ctx):
 
 @polling.command()
 @click.pass_context
-@click.argument('interval', type=click.INT)
+@click.argument('interval', type=click.IntRange(1, 9999))
 def interval(ctx, interval):
-    """CRM polling interval configuration"""
+    """CRM polling interval configuration in seconds (range: 1-9999)"""
     ctx.obj["crm"].config('polling_interval', interval)
 
 @config.group()

--- a/tests/crm_test.py
+++ b/tests/crm_test.py
@@ -1033,6 +1033,8 @@ srv6_nexthop                0               1024
 
 """
 
+crm_config_interval_too_big = "Error: Invalid value for \"INTERVAL\": 30000 is not in the valid range of 1 to 9999."
+
 class TestCrm(object):
     @classmethod
     def setup_class(cls):
@@ -1052,6 +1054,18 @@ class TestCrm(object):
         print(sys.stderr, result.output)
         assert result.exit_code == 0
         assert result.output == crm_new_show_summary
+
+    def test_crm_config_polling_interval(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(crm.cli, ['config', 'polling', 'interval', '10'], obj=db)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+        result = runner.invoke(crm.cli, ['config', 'polling', 'interval', '30000'], obj=db)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 2
+        assert crm_config_interval_too_big in result.output
+
 
     def test_crm_show_thresholds_acl_group(self):
         runner = CliRunner()


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
add checking for range for CRM interval

#### How I did it
add attribute **click.IntRange(1, 9999)** and UT to verify it (according to [CRM HLD](https://github.com/sonic-net/SONiC/blob/master/doc/crm/Critical-Resource-Monitoring-High-Level-Design.md#211-crm-table))

#### How to verify it
1) run UT
2) manual testing: `crm config polling interval 100000000`

#### Previous command output (if the output of a command-line utility has changed)
```
crm config polling interval 4566466
-----------
```

```
crm config polling interval --help
------------
Usage: crm config polling interval [OPTIONS] INTERVAL

  CRM polling interval configuration

Options:
  --help  Show this message and exit.

```

#### New command output (if the output of a command-line utility has changed)
```
crm config polling interval 4566466
-----------
Usage: crm config polling interval [OPTIONS] INTERVAL
Try "crm config polling interval --help" for help.

Error: Invalid value for "INTERVAL": 4566466 is not in the valid range of 1 to 9999.

```

```
crm config polling interval --help
------------
Usage: crm config polling interval [OPTIONS] INTERVAL

  CRM polling interval configuration in seconds (range: 1-9999)

Options:
  --help  Show this message and exit.

```

